### PR TITLE
Add a page_title property to the referral route base class.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ The name of your referral route.
 
 The description of your referral route
 
+### ReferralRoute.page_title
+
+The title to display in the page banner for your route.
+
+Defaults to 'Referral Portal'
+
 ### ReferralRoute.target_teams
 
 The names of the teams to which this route referrs patients.
@@ -50,19 +56,19 @@ referral route.
             # Do whatever you like to episode
             return
 
-### verb
+### ReferralRoute.verb
 
 The verb for the thing this route is doing.
 
 Default = 'Refer'
 
-### progressive_verb
+### ReferralRoute.progressive_verb
 
 The progressive form of the verb this route is doing
 
 Default = 'referring'
 
-### past_verb
+### ReferralRoute.past_verb
 
 The past form of the verb this route is doing
 

--- a/referral/routes.py
+++ b/referral/routes.py
@@ -32,6 +32,7 @@ class ReferralRoute(object):
     target_teams = []
     target_category = None
     success_link = None
+    page_title = None
     verb = 'Refer'
     progressive_verb = 'Referring'
     past_verb = 'Referred'
@@ -73,7 +74,8 @@ class ReferralRoute(object):
             success_link=klass.success_link,
             verb=klass.verb,
             progressive_verb=klass.progressive_verb,
-            past_verb=klass.past_verb
+            past_verb=klass.past_verb,
+            page_title=klass.page_title
         )
 
     def post_create(self, episode, user):

--- a/referral/templates/referral/base.html
+++ b/referral/templates/referral/base.html
@@ -3,7 +3,7 @@
     <div class="panel-heading">
       <h2>
         <i class="fa fa-mail-forward"></i>
-        Referral Portal
+        [[ route.page_title || "Referral Portal" ]]
       </h2>
     </div>
 

--- a/referral/tests/test_api.py
+++ b/referral/tests/test_api.py
@@ -39,13 +39,15 @@ class ReferralViewTestCase(OpalTestCase):
     def test_retrieve_gets_route(self):
         route = self.viewset().list(None)
         expected = {
-            'name'        : 'View Test Route',
-            'description' : 'This is a Route we use for unittests',
-            'slug'        : 'view_test_route',
-            'success_link': '/awesome/fun/times/',
+            'name'            : 'View Test Route',
+            'description'     : 'This is a Route we use for unittests',
+            'slug'            : 'view_test_route',
+            'success_link'    : '/awesome/fun/times/',
             'verb'            : 'Refer',
             'past_verb'       : 'Referred',
-            'progressive_verb': 'Referring'
+            'progressive_verb': 'Referring',
+            'page_title'      : None
+
         }
         self.assertEqual(expected, route.data)
 

--- a/referral/tests/test_referral_routes.py
+++ b/referral/tests/test_referral_routes.py
@@ -23,6 +23,7 @@ class ReferralRouteTestCase(OpalTestCase):
             'verb'            : 'Refer',
             'past_verb'       : 'Referred',
             'progressive_verb': 'Referring',
+            'page_title'      : None
         }
         self.assertEqual(expected, TestRoute.to_dict())
 


### PR DESCRIPTION
This allows us to overwrite the title in the page banner for occasions
on which "Referral Portal is misleading".